### PR TITLE
Allow defining arbitrary field as PK field. Rename PrimaryKeyField -> IdField

### DIFF
--- a/nefertari_sqla/__init__.py
+++ b/nefertari_sqla/__init__.py
@@ -31,7 +31,7 @@ from .fields import (
     UnicodeField,
     UnicodeTextField,
     Relationship,
-    PrimaryKeyField,
+    IdField,
     ForeignKeyField,
     DictField,
 )


### PR DESCRIPTION
``ForeignKeyField`` now required the ``ref_column_type`` argument, which specifies the type of field that is being referenced.