### PR TITLE
Rework usage of field processors

### DIFF
--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -601,14 +601,12 @@ class BaseMixin(object):
         """ Determine if instance is modified.
 
         For instance to be marked as 'modified', it should:
-          * Have PK field set (not newly created)
-          * Have state marked of modified
+          * Have state marked as modified
+          * Have state marked as persistent
           * Any of modified fields have new value
         """
-        pk_set = getattr(self, self.pk_field(), None) is not None
         state = attributes.instance_state(self)
-        modified = state.modified
-        if pk_set and modified:
+        if state.persistent and state.modified:
             for field in state.committed_state.keys():
                 history = state.get_history(field, self)
                 if history.added or history.deleted:
@@ -636,6 +634,7 @@ class BaseDocument(BaseObject, BaseMixin):
         self._bump_version()
         session = session or Session()
         try:
+            self.clean()
             session.add(self)
             session.flush()
             session.expire(self)
@@ -653,6 +652,7 @@ class BaseDocument(BaseObject, BaseMixin):
         try:
             self._update(params)
             self._bump_version()
+            self.clean()
             session = object_session(self)
             session.add(self)
             session.flush()
@@ -665,6 +665,26 @@ class BaseDocument(BaseObject, BaseMixin):
                 detail='Resource `{}` already exists.'.format(
                     self.__class__.__name__),
                 extra={'data': e})
+
+    def clean(self):
+        """ Apply field processors to all changed fields And perform custom
+        field values cleaning before running DB validation.
+
+        Note that at this stage, field values are in the exact same state
+        you posted/set them. E.g. if you set time_field='11/22/2000',
+        self.time_field will be equal to '11/22/2000' here.
+        """
+        columns = {c.key: c for c in class_mapper(self.__class__).columns}
+        state = attributes.instance_state(self)
+        changed_columns = state.committed_state.keys()
+
+        for name in changed_columns:
+            column = columns[name]
+            if hasattr(column, 'apply_processors'):
+                new_value = getattr(self, name)
+                processed_value = column.apply_processors(
+                    instance=self, new_value=new_value)
+                setattr(self, name, processed_value)
 
 
 class ESBaseDocument(BaseDocument):

--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -676,7 +676,11 @@ class BaseDocument(BaseObject, BaseMixin):
         """
         columns = {c.key: c for c in class_mapper(self.__class__).columns}
         state = attributes.instance_state(self)
-        changed_columns = state.committed_state.keys()
+
+        if state.persistent:
+            changed_columns = state.committed_state.keys()
+        else:
+            changed_columns = columns.keys()
 
         for name in changed_columns:
             column = columns[name]

--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -679,7 +679,7 @@ class BaseDocument(BaseObject, BaseMixin):
 
         if state.persistent:
             changed_columns = state.committed_state.keys()
-        else:
+        else:  # New object
             changed_columns = columns.keys()
 
         for name in changed_columns:

--- a/nefertari_sqla/fields.py
+++ b/nefertari_sqla/fields.py
@@ -25,6 +25,20 @@ from .types import (
 )
 
 
+class ProcessableMixin(object):
+    """ Mixin that allows running callables on a value that
+    is being set on a field.
+    """
+    def __init__(self, *args, **kwargs):
+        self.processors = kwargs.pop('processors', ())
+        super(ProcessableMixin, self).__init__(*args, **kwargs)
+
+    def apply_processors(self, instance, new_value):
+        for proc in self.processors:
+            new_value = proc(instance=instance, new_value=new_value)
+        return new_value
+
+
 class BaseField(Column):
     """ Base plain column that otherwise would be created as
     sqlalchemy.Column(sqlalchemy.Type())
@@ -113,14 +127,14 @@ class BaseField(Column):
         return self.__class__
 
 
-class BigIntegerField(BaseField):
+class BigIntegerField(ProcessableMixin, BaseField):
     _sqla_type = LimitedBigInteger
-    _type_unchanged_kwargs = ('min_value', 'max_value', 'processors')
+    _type_unchanged_kwargs = ('min_value', 'max_value')
 
 
-class BooleanField(BaseField):
+class BooleanField(ProcessableMixin, BaseField):
     _sqla_type = ProcessableBoolean
-    _type_unchanged_kwargs = ('create_constraint', 'processors')
+    _type_unchanged_kwargs = ('create_constraint')
 
     def process_type_args(self, kwargs):
         """
@@ -135,33 +149,33 @@ class BooleanField(BaseField):
         return type_args, type_kw, cleaned_kw
 
 
-class DateField(BaseField):
+class DateField(ProcessableMixin, BaseField):
     _sqla_type = ProcessableDate
-    _type_unchanged_kwargs = ('processors',)
+    _type_unchanged_kwargs = ()
 
 
-class DateTimeField(BaseField):
+class DateTimeField(ProcessableMixin, BaseField):
     _sqla_type = ProcessableDateTime
-    _type_unchanged_kwargs = ('timezone', 'processors')
+    _type_unchanged_kwargs = ('timezone',)
 
 
-class ChoiceField(BaseField):
+class ChoiceField(ProcessableMixin, BaseField):
     _sqla_type = ProcessableChoice
     _type_unchanged_kwargs = (
         'collation', 'convert_unicode', 'unicode_error',
-        '_warn_on_bytestring', 'choices', 'processors')
+        '_warn_on_bytestring', 'choices')
 
 
-class FloatField(BaseField):
+class FloatField(ProcessableMixin, BaseField):
     _sqla_type = LimitedFloat
     _type_unchanged_kwargs = (
         'precision', 'asdecimal', 'decimal_return_scale',
-        'min_value', 'max_value', 'processors')
+        'min_value', 'max_value')
 
 
-class IntegerField(BaseField):
+class IntegerField(ProcessableMixin, BaseField):
     _sqla_type = LimitedInteger
-    _type_unchanged_kwargs = ('min_value', 'max_value', 'processors')
+    _type_unchanged_kwargs = ('min_value', 'max_value')
 
 
 class IdField(IntegerField):
@@ -171,46 +185,44 @@ class IdField(IntegerField):
     pass
 
 
-class IntervalField(BaseField):
+class IntervalField(ProcessableMixin, BaseField):
     _sqla_type = ProcessableInterval
     _type_unchanged_kwargs = (
-        'native', 'second_precision', 'day_precision', 'processors')
+        'native', 'second_precision', 'day_precision')
 
 
-class BinaryField(BaseField):
+class BinaryField(ProcessableMixin, BaseField):
     _sqla_type = ProcessableLargeBinary
-    _type_unchanged_kwargs = ('length', 'processors')
+    _type_unchanged_kwargs = ('length',)
 
 # Since SQLAlchemy 1.0.0
 # class MatchField(BooleanField):
 #     _sqla_type = MatchType
 
 
-class DecimalField(BaseField):
+class DecimalField(ProcessableMixin, BaseField):
     _sqla_type = LimitedNumeric
     _type_unchanged_kwargs = (
         'precision', 'scale', 'decimal_return_scale', 'asdecimal',
-        'min_value', 'max_value', 'processors')
+        'min_value', 'max_value')
 
 
-class PickleField(BaseField):
+class PickleField(ProcessableMixin, BaseField):
     _sqla_type = ProcessablePickleType
     _type_unchanged_kwargs = (
-        'protocol', 'pickler', 'comparator',
-        'processors')
+        'protocol', 'pickler', 'comparator')
 
 
-class SmallIntegerField(BaseField):
+class SmallIntegerField(ProcessableMixin, BaseField):
     _sqla_type = LimitedSmallInteger
-    _type_unchanged_kwargs = ('min_value', 'max_value', 'processors')
+    _type_unchanged_kwargs = ('min_value', 'max_value')
 
 
-class StringField(BaseField):
+class StringField(ProcessableMixin, BaseField):
     _sqla_type = LimitedString
     _type_unchanged_kwargs = (
         'collation', 'convert_unicode', 'unicode_error',
-        '_warn_on_bytestring', 'min_length', 'max_length',
-        'processors')
+        '_warn_on_bytestring', 'min_length', 'max_length')
 
     def process_type_args(self, kwargs):
         """

--- a/nefertari_sqla/tests/test_documents.py
+++ b/nefertari_sqla/tests/test_documents.py
@@ -617,26 +617,33 @@ class TestBaseDocument(object):
             __tablename__ = 'mymodel'
             id = fields.IdField(primary_key=True)
             name = fields.StringField(processors=[processor])
+            email = fields.StringField(processors=[processor])
         memory_db()
 
         obj = MyModel(name='myname')
         obj.clean()
         assert obj.name == 'foobar'
+        assert obj.email == 'foobar'
 
     def test_clean_existing_object(self, memory_db):
-        processor = lambda instance, new_value: new_value.lower()
+        processor = lambda instance, new_value: new_value + '-'
 
         class MyModel(docs.BaseDocument):
             __tablename__ = 'mymodel'
             id = fields.IdField(primary_key=True)
             name = fields.StringField(processors=[processor])
+            email = fields.StringField(processors=[processor])
         memory_db()
 
-        obj = MyModel(id=1, name='myname').save()
+        obj = MyModel(id=1, name='myname', email='FOO').save()
+        assert obj.name == 'myname-'
+        assert obj.email == 'FOO-'
+
         obj = MyModel.get(id=1)
-        obj.name = 'SUPERNAME'
+        obj.name = 'supername'
         obj.clean()
-        assert obj.name == 'supername'
+        assert obj.name == 'supername-'
+        assert obj.email == 'FOO-'
 
 
 class TestGetCollection(object):

--- a/nefertari_sqla/tests/test_types.py
+++ b/nefertari_sqla/tests/test_types.py
@@ -14,27 +14,6 @@ class DemoClass(object):
         pass
 
 
-class TestProcessableMixin(object):
-
-    class Processable(types.ProcessableMixin, DemoClass):
-        pass
-
-    def test_process_bind_param(self):
-        processors = [
-            lambda v: v.lower(),
-            lambda v: v.strip(),
-            lambda v: 'Processed ' + v,
-        ]
-        mixin = self.Processable(processors=processors)
-        value = mixin.process_bind_param(' WeIrd ValUE   ', None)
-        assert value == 'Processed weird value'
-
-    def test_process_bind_param_no_processors(self):
-        mixin = self.Processable()
-        value = mixin.process_bind_param(' WeIrd ValUE   ', None)
-        assert value == ' WeIrd ValUE   '
-
-
 class TestLengthLimitedStringMixin(object):
 
     class Limited(types.LengthLimitedStringMixin, DemoClass):
@@ -154,15 +133,6 @@ class TestProcessableChoice(object):
         field = types.ProcessableChoice(choices=['foo'])
         try:
             field.process_bind_param('foo', None)
-        except ValueError:
-            raise Exception('Unexpected error')
-
-    def test_processed_value_in_choices(self):
-        field = types.ProcessableChoice(
-            choices=['foo'],
-            processors=[lambda v: v.lower()])
-        try:
-            field.process_bind_param('FoO', None)
         except ValueError:
             raise Exception('Unexpected error')
 


### PR DESCRIPTION
* Field processors are now stored on generated columns, in 'processors'
  attribute.
* Processors are now run at from BaseDocument methods `save` and `update`
  by calling new BaseDocument.clean method.
* BaseDocument.clean method added. Current implementation calls field
  processors for those columns that are 'processable'.
* Processors are now passed 2 keyword arguments:
    1. instance - document instance with all new values set but neither
     processed, nor type-converted.
    2. new_value - value that was set to object.