### PR TITLE
Split processors to pre_ and post_ processors

### DIFF
--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -67,11 +67,11 @@ TYPES_MAP = {
     types.LimitedText: {'type': 'string'},
     types.LimitedUnicode: {'type': 'string'},
     types.LimitedUnicodeText: {'type': 'string'},
-    types.ProcessableChoice: {'type': 'string'},
+    types.Choice: {'type': 'string'},
 
-    types.ProcessableBoolean: {'type': 'boolean'},
-    types.ProcessableLargeBinary: {'type': 'object'},
-    types.ProcessableDict: {'type': 'object'},
+    types.Boolean: {'type': 'boolean'},
+    types.LargeBinary: {'type': 'object'},
+    types.Dict: {'type': 'object'},
 
     types.LimitedNumeric: {'type': 'double'},
     types.LimitedFloat: {'type': 'double'},
@@ -79,11 +79,11 @@ TYPES_MAP = {
     types.LimitedInteger: {'type': 'long'},
     types.LimitedBigInteger: {'type': 'long'},
     types.LimitedSmallInteger: {'type': 'long'},
-    types.ProcessableInterval: {'type': 'long'},
+    types.Interval: {'type': 'long'},
 
-    types.ProcessableDateTime: {'type': 'date', 'format': 'dateOptionalTime'},
-    types.ProcessableDate: {'type': 'date', 'format': 'dateOptionalTime'},
-    types.ProcessableTime: {'type': 'date', 'format': 'HH:mm:ss'},
+    types.DateTime: {'type': 'date', 'format': 'dateOptionalTime'},
+    types.Date: {'type': 'date', 'format': 'dateOptionalTime'},
+    types.Time: {'type': 'date', 'format': 'HH:mm:ss'},
 }
 
 
@@ -124,7 +124,7 @@ class BaseMixin(object):
 
         for name, column in columns.items():
             column_type = column.type
-            if isinstance(column_type, types.ProcessableChoiceArray):
+            if isinstance(column_type, types.ChoiceArray):
                 column_type = column_type.impl.item_type
             column_type = type(column_type)
             if column_type not in TYPES_MAP:

--- a/nefertari_sqla/fields.py
+++ b/nefertari_sqla/fields.py
@@ -12,16 +12,16 @@ from .types import (
     LimitedFloat,
     LimitedNumeric,
     LimitedUnicodeText,
-    ProcessableDateTime,
-    ProcessableBoolean,
-    ProcessableDate,
-    ProcessableInterval,
-    ProcessableLargeBinary,
-    ProcessablePickleType,
-    ProcessableTime,
-    ProcessableChoice,
-    ProcessableDict,
-    ProcessableChoiceArray,
+    DateTime,
+    Boolean,
+    Date,
+    Interval,
+    LargeBinary,
+    PickleType,
+    Time,
+    Choice,
+    Dict,
+    ChoiceArray,
 )
 
 
@@ -142,7 +142,7 @@ class BigIntegerField(ProcessableMixin, BaseField):
 
 
 class BooleanField(ProcessableMixin, BaseField):
-    _sqla_type = ProcessableBoolean
+    _sqla_type = Boolean
     _type_unchanged_kwargs = ('create_constraint')
 
     def process_type_args(self, kwargs):
@@ -159,17 +159,17 @@ class BooleanField(ProcessableMixin, BaseField):
 
 
 class DateField(ProcessableMixin, BaseField):
-    _sqla_type = ProcessableDate
+    _sqla_type = Date
     _type_unchanged_kwargs = ()
 
 
 class DateTimeField(ProcessableMixin, BaseField):
-    _sqla_type = ProcessableDateTime
+    _sqla_type = DateTime
     _type_unchanged_kwargs = ('timezone',)
 
 
 class ChoiceField(ProcessableMixin, BaseField):
-    _sqla_type = ProcessableChoice
+    _sqla_type = Choice
     _type_unchanged_kwargs = (
         'collation', 'convert_unicode', 'unicode_error',
         '_warn_on_bytestring', 'choices')
@@ -195,13 +195,13 @@ class IdField(IntegerField):
 
 
 class IntervalField(ProcessableMixin, BaseField):
-    _sqla_type = ProcessableInterval
+    _sqla_type = Interval
     _type_unchanged_kwargs = (
         'native', 'second_precision', 'day_precision')
 
 
 class BinaryField(ProcessableMixin, BaseField):
-    _sqla_type = ProcessableLargeBinary
+    _sqla_type = LargeBinary
     _type_unchanged_kwargs = ('length',)
 
 # Since SQLAlchemy 1.0.0
@@ -217,7 +217,7 @@ class DecimalField(ProcessableMixin, BaseField):
 
 
 class PickleField(ProcessableMixin, BaseField):
-    _sqla_type = ProcessablePickleType
+    _sqla_type = PickleType
     _type_unchanged_kwargs = (
         'protocol', 'pickler', 'comparator')
 
@@ -251,7 +251,7 @@ class TextField(StringField):
 
 
 class TimeField(DateTimeField):
-    _sqla_type = ProcessableTime
+    _sqla_type = Time
 
 
 class UnicodeField(StringField):
@@ -263,7 +263,7 @@ class UnicodeTextField(StringField):
 
 
 class DictField(BaseField):
-    _sqla_type = ProcessableDict
+    _sqla_type = Dict
     _type_unchanged_kwargs = ()
 
     def process_type_args(self, kwargs):
@@ -274,7 +274,7 @@ class DictField(BaseField):
 
 
 class ListField(BaseField):
-    _sqla_type = ProcessableChoiceArray
+    _sqla_type = ChoiceArray
     _type_unchanged_kwargs = (
         'as_tuple', 'dimensions', 'zero_indexes', 'choices')
 

--- a/nefertari_sqla/fields.py
+++ b/nefertari_sqla/fields.py
@@ -30,11 +30,17 @@ class ProcessableMixin(object):
     is being set on a field.
     """
     def __init__(self, *args, **kwargs):
-        self.processors = kwargs.pop('processors', ())
+        self.pre_processors = kwargs.pop('pre_processors', ())
+        self.post_processors = kwargs.pop('post_processors', ())
         super(ProcessableMixin, self).__init__(*args, **kwargs)
 
-    def apply_processors(self, instance, new_value):
-        for proc in self.processors:
+    def apply_processors(self, instance, new_value, pre=False, post=False):
+        processors = []
+        if pre:
+            processors += list(self.pre_processors)
+        if post:
+            processors += list(self.post_processors)
+        for proc in processors:
             new_value = proc(instance=instance, new_value=new_value)
         return new_value
 

--- a/nefertari_sqla/fields.py
+++ b/nefertari_sqla/fields.py
@@ -30,22 +30,23 @@ class ProcessableMixin(object):
     is being set on a field.
     """
     def __init__(self, *args, **kwargs):
-        """ Pop pre/post processors
+        """ Pop before/after validation processors
 
-        :pre_processors: Processors that are run before session.flush()
-        :post_processors: Processors that are run after session.flush() but
-            before session.commit()
+        :before_validation: Processors that are run before session.flush()
+        :after_validation: Processors that are run after session.flush()
+            but before session.commit()
         """
-        self.pre_processors = kwargs.pop('pre_processors', ())
-        self.post_processors = kwargs.pop('post_processors', ())
+        self.before_validation = kwargs.pop('before_validation', ())
+        self.after_validation = kwargs.pop('after_validation', ())
         super(ProcessableMixin, self).__init__(*args, **kwargs)
 
-    def apply_processors(self, instance, new_value, pre=False, post=False):
+    def apply_processors(self, instance, new_value,
+                         before=False, after=False):
         processors = []
-        if pre:
-            processors += list(self.pre_processors)
-        if post:
-            processors += list(self.post_processors)
+        if before:
+            processors += list(self.before_validation)
+        if after:
+            processors += list(self.after_validation)
         for proc in processors:
             new_value = proc(instance=instance, new_value=new_value)
         return new_value

--- a/nefertari_sqla/fields.py
+++ b/nefertari_sqla/fields.py
@@ -30,6 +30,12 @@ class ProcessableMixin(object):
     is being set on a field.
     """
     def __init__(self, *args, **kwargs):
+        """ Pop pre/post processors
+
+        :pre_processors: Processors that are run before session.flush()
+        :post_processors: Processors that are run after session.flush() but
+            before session.commit()
+        """
         self.pre_processors = kwargs.pop('pre_processors', ())
         self.post_processors = kwargs.pop('post_processors', ())
         super(ProcessableMixin, self).__init__(*args, **kwargs)

--- a/nefertari_sqla/tests/test_documents.py
+++ b/nefertari_sqla/tests/test_documents.py
@@ -645,8 +645,8 @@ class TestBaseDocument(object):
         class MyModel(docs.BaseDocument):
             __tablename__ = 'mymodel'
             id = fields.IdField(primary_key=True)
-            name = fields.StringField(processors=[processor])
-            email = fields.StringField(processors=[processor])
+            name = fields.StringField(pre_processors=[processor])
+            email = fields.StringField(pre_processors=[processor])
         memory_db()
 
         obj = MyModel(name='myname')
@@ -660,8 +660,8 @@ class TestBaseDocument(object):
         class MyModel(docs.BaseDocument):
             __tablename__ = 'mymodel'
             id = fields.IdField(primary_key=True)
-            name = fields.StringField(processors=[processor])
-            email = fields.StringField(processors=[processor])
+            name = fields.StringField(pre_processors=[processor])
+            email = fields.StringField(pre_processors=[processor])
         memory_db()
 
         obj = MyModel(id=1, name='myname', email='FOO').save()

--- a/nefertari_sqla/tests/test_types.py
+++ b/nefertari_sqla/tests/test_types.py
@@ -114,10 +114,10 @@ class TestSizeLimitedNumberMixin(object):
             raise Exception('Unexpected exception')
 
 
-class TestProcessableChoice(object):
+class TestChoice(object):
 
     def test_no_choices(self):
-        field = types.ProcessableChoice()
+        field = types.Choice()
         field._column_name = 'foo'
         with pytest.raises(ValueError) as ex:
             field.process_bind_param('foo', None)
@@ -125,14 +125,14 @@ class TestProcessableChoice(object):
             'Field `foo`: Got an invalid choice `foo`. Valid choices: ()'
 
     def test_none_value(self):
-        field = types.ProcessableChoice()
+        field = types.Choice()
         try:
             field.process_bind_param(None, None)
         except ValueError:
             raise Exception('Unexpected error')
 
     def test_value_not_in_choices(self):
-        field = types.ProcessableChoice(choices=['foo'])
+        field = types.Choice(choices=['foo'])
         field._column_name = 'foo'
         with pytest.raises(ValueError) as ex:
             field.process_bind_param('bar', None)
@@ -140,38 +140,38 @@ class TestProcessableChoice(object):
             'Field `foo`: Got an invalid choice `bar`. Valid choices: (foo)'
 
     def test_value_in_choices(self):
-        field = types.ProcessableChoice(choices=['foo'])
+        field = types.Choice(choices=['foo'])
         try:
             field.process_bind_param('foo', None)
         except ValueError:
             raise Exception('Unexpected error')
 
     def test_choices_not_sequence(self):
-        field = types.ProcessableChoice(choices='foo')
+        field = types.Choice(choices='foo')
         try:
             field.process_bind_param('foo', None)
         except ValueError:
             raise Exception('Unexpected error')
 
 
-class TestProcessableInterval(object):
+class TestInterval(object):
 
     def test_passing_seconds(self):
-        field = types.ProcessableInterval()
+        field = types.Interval()
         value = field.process_bind_param(36000, None)
         assert isinstance(value, datetime.timedelta)
         assert value.seconds == 36000
 
     def test_passing_timedelta(self):
-        field = types.ProcessableInterval()
+        field = types.Interval()
         value = field.process_bind_param(datetime.timedelta(seconds=60), None)
         assert isinstance(value, datetime.timedelta)
 
 
-class TestProcessableDict(object):
+class TestDict(object):
 
     def test_load_dialect_impl_postgresql(self):
-        field = types.ProcessableDict()
+        field = types.Dict()
         dialect = Mock()
         dialect.name = 'postgresql'
         field.load_dialect_impl(dialect=dialect)
@@ -180,7 +180,7 @@ class TestProcessableDict(object):
 
     def test_load_dialect_impl_not_postgresql(self):
         from sqlalchemy.types import UnicodeText
-        field = types.ProcessableDict()
+        field = types.Dict()
         dialect = Mock()
         dialect.name = 'some_other'
         field.load_dialect_impl(dialect=dialect)
@@ -188,36 +188,36 @@ class TestProcessableDict(object):
         dialect.type_descriptor.assert_called_once_with(UnicodeText)
 
     def test_process_bind_param_postgres(self):
-        field = types.ProcessableDict()
+        field = types.Dict()
         dialect = Mock()
         dialect.name = 'postgresql'
         assert {'q': 'f'} == field.process_bind_param({'q': 'f'}, dialect)
 
     def test_process_bind_param_not_postgres(self):
-        field = types.ProcessableDict()
+        field = types.Dict()
         dialect = Mock()
         dialect.name = 'some_other'
         assert '{"q": "f"}' == field.process_bind_param({'q': 'f'}, dialect)
 
     def test_process_result_value_postgres(self):
-        field = types.ProcessableDict()
+        field = types.Dict()
         dialect = Mock()
         dialect.name = 'postgresql'
         assert {'q': 'f'} == field.process_result_value({'q': 'f'}, dialect)
 
     def test_process_result_value_not_postgres(self):
-        field = types.ProcessableDict()
+        field = types.Dict()
         dialect = Mock()
         dialect.name = 'some_other'
         assert {'q': 'f'} == field.process_result_value('{"q": "f"}', dialect)
 
 
-class TestProcessableChoiceArray(object):
+class TestChoiceArray(object):
 
     @patch.object(types, 'ARRAY')
     @patch.object(types.types, 'UnicodeText')
     def test_load_dialect_impl_postgresql(self, mock_unic, mock_array):
-        field = types.ProcessableChoiceArray(item_type=fields.StringField)
+        field = types.ChoiceArray(item_type=fields.StringField)
         dialect = Mock()
         dialect.name = 'postgresql'
         field.load_dialect_impl(dialect=dialect)
@@ -228,7 +228,7 @@ class TestProcessableChoiceArray(object):
     @patch.object(types, 'ARRAY')
     @patch.object(types.types, 'UnicodeText')
     def test_load_dialect_impl_not_postgresql(self, mock_unic, mock_array):
-        field = types.ProcessableChoiceArray(item_type=fields.StringField)
+        field = types.ChoiceArray(item_type=fields.StringField)
         dialect = Mock()
         dialect.name = 'some_other'
         field.load_dialect_impl(dialect=dialect)
@@ -237,12 +237,12 @@ class TestProcessableChoiceArray(object):
         assert not mock_array.called
 
     def test_choices_not_sequence(self):
-        field = types.ProcessableChoiceArray(
+        field = types.ChoiceArray(
             item_type=fields.StringField, choices='foo')
         assert field.choices == ['foo']
 
     def test_validate_choices_no_choices(self):
-        field = types.ProcessableChoiceArray(item_type=fields.StringField)
+        field = types.ChoiceArray(item_type=fields.StringField)
         assert field.choices is None
         try:
             field._validate_choices(['foo'])
@@ -250,7 +250,7 @@ class TestProcessableChoiceArray(object):
             raise Exception('Unexpected error')
 
     def test_validate_choices_no_value(self):
-        field = types.ProcessableChoiceArray(
+        field = types.ChoiceArray(
             item_type=fields.StringField, choices=['foo'])
         try:
             field._validate_choices(None)
@@ -258,7 +258,7 @@ class TestProcessableChoiceArray(object):
             raise Exception('Unexpected error')
 
     def test_validate_choices_valid(self):
-        field = types.ProcessableChoiceArray(
+        field = types.ChoiceArray(
             item_type=fields.StringField,
             choices=['foo', 'bar'])
         try:
@@ -267,7 +267,7 @@ class TestProcessableChoiceArray(object):
             raise Exception('Unexpected error')
 
     def test_validate_choices_invalid(self):
-        field = types.ProcessableChoiceArray(
+        field = types.ChoiceArray(
             item_type=fields.StringField,
             choices=['foo', 'bar'])
         field._column_name = 'mycol'
@@ -278,25 +278,25 @@ class TestProcessableChoiceArray(object):
             'Valid choices: (foo, bar)')
 
     def test_process_bind_param_postgres(self):
-        field = types.ProcessableChoiceArray(item_type=fields.StringField)
+        field = types.ChoiceArray(item_type=fields.StringField)
         dialect = Mock()
         dialect.name = 'postgresql'
         assert ['q'] == field.process_bind_param(['q'], dialect)
 
     def test_process_bind_param_not_postgres(self):
-        field = types.ProcessableChoiceArray(item_type=fields.StringField)
+        field = types.ChoiceArray(item_type=fields.StringField)
         dialect = Mock()
         dialect.name = 'some_other'
         assert '["q"]' == field.process_bind_param(['q'], dialect)
 
     def test_process_result_value_postgres(self):
-        field = types.ProcessableChoiceArray(item_type=fields.StringField)
+        field = types.ChoiceArray(item_type=fields.StringField)
         dialect = Mock()
         dialect.name = 'postgresql'
         assert ['q'] == field.process_result_value(['q'], dialect)
 
     def test_process_result_value_not_postgres(self):
-        field = types.ProcessableChoiceArray(item_type=fields.StringField)
+        field = types.ChoiceArray(item_type=fields.StringField)
         dialect = Mock()
         dialect.name = 'some_other'
         assert ['q'] == field.process_result_value('["q"]', dialect)

--- a/nefertari_sqla/types.py
+++ b/nefertari_sqla/types.py
@@ -97,21 +97,19 @@ class LimitedNumeric(SizeLimitedNumberMixin, types.TypeDecorator):
     impl = types.Numeric
 
 
-# Types that support running processors
-
-class ProcessableDateTime(types.TypeDecorator):
+class DateTime(types.TypeDecorator):
     impl = types.DateTime
 
 
-class ProcessableBoolean(types.TypeDecorator):
+class Boolean(types.TypeDecorator):
     impl = types.Boolean
 
 
-class ProcessableDate(types.TypeDecorator):
+class Date(types.TypeDecorator):
     impl = types.Date
 
 
-class ProcessableChoice(types.TypeDecorator):
+class Choice(types.TypeDecorator):
     """ Type that represents value from a particular set of choices.
 
     Value may be any number of choices from a provided set of
@@ -124,7 +122,7 @@ class ProcessableChoice(types.TypeDecorator):
         self.choices = kwargs.pop('choices', ())
         if not isinstance(self.choices, (list, tuple, set)):
             self.choices = [self.choices]
-        super(ProcessableChoice, self).__init__(*args, **kwargs)
+        super(Choice, self).__init__(*args, **kwargs)
 
     def process_bind_param(self, value, dialect):
         if (value is not None) and (value not in self.choices):
@@ -134,7 +132,7 @@ class ProcessableChoice(types.TypeDecorator):
         return value
 
 
-class ProcessableInterval(types.TypeDecorator):
+class Interval(types.TypeDecorator):
     impl = types.Interval
 
     def process_bind_param(self, value, dialect):
@@ -144,19 +142,19 @@ class ProcessableInterval(types.TypeDecorator):
         return value
 
 
-class ProcessableLargeBinary(types.TypeDecorator):
+class LargeBinary(types.TypeDecorator):
     impl = types.LargeBinary
 
 
-class ProcessablePickleType(types.TypeDecorator):
+class PickleType(types.TypeDecorator):
     impl = types.PickleType
 
 
-class ProcessableTime(types.TypeDecorator):
+class Time(types.TypeDecorator):
     impl = types.Time
 
 
-class ProcessableDict(types.TypeDecorator):
+class Dict(types.TypeDecorator):
     """ Represents a dictionary of values.
 
 
@@ -193,7 +191,7 @@ class ProcessableDict(types.TypeDecorator):
         return value
 
 
-class ProcessableChoiceArray(types.TypeDecorator):
+class ChoiceArray(types.TypeDecorator):
     """ Represents a list of values.
 
     If 'postgresql' is used, postgress.ARRAY type is used for db column
@@ -211,7 +209,7 @@ class ProcessableChoiceArray(types.TypeDecorator):
                 self.choices, (list, tuple, set)):
             self.choices = [self.choices]
         self.kwargs = kwargs
-        super(ProcessableChoiceArray, self).__init__(*args, **kwargs)
+        super(ChoiceArray, self).__init__(*args, **kwargs)
 
     def load_dialect_impl(self, dialect):
         """ Based on :dialect.name: determine type to be used.


### PR DESCRIPTION
Also:
* Remove `Processable` prefix from type names 
* Fix BaseDocument.get_or_create to save created object