### PR TITLE
Rename _sqla_type to _sqla_type_cls to avoid conflicts

### DIFF
--- a/nefertari_sqla/fields.py
+++ b/nefertari_sqla/fields.py
@@ -57,16 +57,16 @@ class BaseField(Column):
     sqlalchemy.Column(sqlalchemy.Type())
 
     Attributes:
-        _sqla_type: SQLAlchemy type class used to instantiate the column type.
+        _sqla_type_cls: SQLAlchemy type class used to instantiate the column type.
         _type_unchanged_kwargs: sequence of strings that represent arguments
-            received by `_sqla_type`, the names of which have not been
+            received by `_sqla_type_cls`, the names of which have not been
             changed. Values of field init arguments with these names will
             be extracted from field init kwargs and passed to Type init
             as is.
         _column_valid_kwargs: sequence of string names of valid kwargs that
             a Column may receive.
     """
-    _sqla_type = None
+    _sqla_type_cls = None
     _type_unchanged_kwargs = ()
     _column_valid_kwargs = (
         'name', 'type_', 'autoincrement', 'default', 'doc', 'key', 'index',
@@ -87,7 +87,7 @@ class BaseField(Column):
             col_kw['name'], col_kw['type_'] = args
         # Column init when defining a schema
         else:
-            col_kw['type_'] = self._sqla_type(*type_args, **type_kw)
+            col_kw['type_'] = self._sqla_type_cls(*type_args, **type_kw)
         super(BaseField, self).__init__(**col_kw)
 
     def __setattr__(self, key, value):
@@ -150,12 +150,12 @@ class BaseField(Column):
         return self.__class__
 
 class BigIntegerField(ProcessableMixin, BaseField):
-    _sqla_type = LimitedBigInteger
+    _sqla_type_cls = LimitedBigInteger
     _type_unchanged_kwargs = ('min_value', 'max_value')
 
 
 class BooleanField(ProcessableMixin, BaseField):
-    _sqla_type = Boolean
+    _sqla_type_cls = Boolean
     _type_unchanged_kwargs = ('create_constraint')
 
     def process_type_args(self, kwargs):
@@ -172,31 +172,31 @@ class BooleanField(ProcessableMixin, BaseField):
 
 
 class DateField(ProcessableMixin, BaseField):
-    _sqla_type = Date
+    _sqla_type_cls = Date
     _type_unchanged_kwargs = ()
 
 
 class DateTimeField(ProcessableMixin, BaseField):
-    _sqla_type = DateTime
+    _sqla_type_cls = DateTime
     _type_unchanged_kwargs = ('timezone',)
 
 
 class ChoiceField(ProcessableMixin, BaseField):
-    _sqla_type = Choice
+    _sqla_type_cls = Choice
     _type_unchanged_kwargs = (
         'collation', 'convert_unicode', 'unicode_error',
         '_warn_on_bytestring', 'choices')
 
 
 class FloatField(ProcessableMixin, BaseField):
-    _sqla_type = LimitedFloat
+    _sqla_type_cls = LimitedFloat
     _type_unchanged_kwargs = (
         'precision', 'asdecimal', 'decimal_return_scale',
         'min_value', 'max_value')
 
 
 class IntegerField(ProcessableMixin, BaseField):
-    _sqla_type = LimitedInteger
+    _sqla_type_cls = LimitedInteger
     _type_unchanged_kwargs = ('min_value', 'max_value')
 
 
@@ -208,40 +208,40 @@ class IdField(IntegerField):
 
 
 class IntervalField(ProcessableMixin, BaseField):
-    _sqla_type = Interval
+    _sqla_type_cls = Interval
     _type_unchanged_kwargs = (
         'native', 'second_precision', 'day_precision')
 
 
 class BinaryField(ProcessableMixin, BaseField):
-    _sqla_type = LargeBinary
+    _sqla_type_cls = LargeBinary
     _type_unchanged_kwargs = ('length',)
 
 # Since SQLAlchemy 1.0.0
 # class MatchField(BooleanField):
-#     _sqla_type = MatchType
+#     _sqla_type_cls = MatchType
 
 
 class DecimalField(ProcessableMixin, BaseField):
-    _sqla_type = LimitedNumeric
+    _sqla_type_cls = LimitedNumeric
     _type_unchanged_kwargs = (
         'precision', 'scale', 'decimal_return_scale', 'asdecimal',
         'min_value', 'max_value')
 
 
 class PickleField(ProcessableMixin, BaseField):
-    _sqla_type = PickleType
+    _sqla_type_cls = PickleType
     _type_unchanged_kwargs = (
         'protocol', 'pickler', 'comparator')
 
 
 class SmallIntegerField(ProcessableMixin, BaseField):
-    _sqla_type = LimitedSmallInteger
+    _sqla_type_cls = LimitedSmallInteger
     _type_unchanged_kwargs = ('min_value', 'max_value')
 
 
 class StringField(ProcessableMixin, BaseField):
-    _sqla_type = LimitedString
+    _sqla_type_cls = LimitedString
     _type_unchanged_kwargs = (
         'collation', 'convert_unicode', 'unicode_error',
         '_warn_on_bytestring', 'min_length', 'max_length')
@@ -260,23 +260,23 @@ class StringField(ProcessableMixin, BaseField):
 
 
 class TextField(StringField):
-    _sqla_type = LimitedText
+    _sqla_type_cls = LimitedText
 
 
 class TimeField(DateTimeField):
-    _sqla_type = Time
+    _sqla_type_cls = Time
 
 
 class UnicodeField(StringField):
-    _sqla_type = LimitedUnicode
+    _sqla_type_cls = LimitedUnicode
 
 
 class UnicodeTextField(StringField):
-    _sqla_type = LimitedUnicodeText
+    _sqla_type_cls = LimitedUnicodeText
 
 
 class DictField(BaseField):
-    _sqla_type = Dict
+    _sqla_type_cls = Dict
     _type_unchanged_kwargs = ()
 
     def process_type_args(self, kwargs):
@@ -287,12 +287,12 @@ class DictField(BaseField):
 
 
 class ListField(BaseField):
-    _sqla_type = ChoiceArray
+    _sqla_type_cls = ChoiceArray
     _type_unchanged_kwargs = (
         'as_tuple', 'dimensions', 'zero_indexes', 'choices')
 
     def process_type_args(self, kwargs):
-        """ Covert field class to its `_sqla_type`.
+        """ Covert field class to its `_sqla_type_cls`.
 
         StringField & UnicodeField are replaced with corresponding
         Text fields because when String* fields are used, SQLA creates
@@ -313,7 +313,7 @@ class ListField(BaseField):
             if item_type_field is UnicodeField:
                 item_type_field = UnicodeTextField
 
-            type_kw['item_type'] = item_type_field._sqla_type
+            type_kw['item_type'] = item_type_field._sqla_type_cls
 
         cleaned_kw['default'] = cleaned_kw.get('default') or []
 
@@ -358,7 +358,7 @@ class BaseSchemaItemField(BaseField):
             column_kw['name'], column_kw['type_'], schema_item = args
         # Column init when defining a schema
         else:
-            column_kw['type_'] = self._sqla_type(*type_args, **type_kw)
+            column_kw['type_'] = self._sqla_type_cls(*type_args, **type_kw)
         column_args = (schema_item,)
         return Column.__init__(self, *column_args, **column_kw)
 
@@ -390,7 +390,7 @@ class ForeignKeyField(BaseSchemaItemField):
     model to add/update relationship. Use `Relationship` constructor
     with backreference settings instead.
     """
-    _sqla_type = None
+    _sqla_type_cls = None
     _type_unchanged_kwargs = ()
     _schema_class = ForeignKey
     _schema_kwarg_prefix = 'ref_'
@@ -399,17 +399,17 @@ class ForeignKeyField(BaseSchemaItemField):
         'ondelete', 'deferrable', 'initially', 'link_to_name', 'match')
 
     def __init__(self, *args, **kwargs):
-        """ Override to determine `self._sqla_type`.
+        """ Override to determine `self._sqla_type_cls`.
 
         Type is determined using 'ref_column_type' value from :kwargs:.
         Its value must be a *Field class of a field that is being
-        referenced by FK field or a `_sqla_type` of that *Field cls.
+        referenced by FK field or a `_sqla_type_cls` of that *Field cls.
         """
         if not args:
             field_type = kwargs.pop(self._schema_kwarg_prefix + 'column_type')
-            if hasattr(field_type, '_sqla_type'):
-                field_type = field_type._sqla_type
-            self._sqla_type = field_type
+            if hasattr(field_type, '_sqla_type_cls'):
+                field_type = field_type._sqla_type_cls
+            self._sqla_type_cls = field_type
         super(ForeignKeyField, self).__init__(*args, **kwargs)
 
     def _get_referential_action(self, kwargs, key):


### PR DESCRIPTION
As it turned out, SQLA type system has boolean named the same way which raised an error when generating ApiKey model from nefertari.

https://github.com/zzzeek/sqlalchemy/blob/606a9b02e5c6081878aa331d1d2c3a678a671904/lib/sqlalchemy/sql/type_api.py#L40