### PR TITLE
Explicitly reindex old one-to-one value

### DIFF
--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -671,11 +671,6 @@ class BaseMixin(object):
             # If 'Many' side should be indexed, its value is already a list.
             if value is None or isinstance(value, list):
                 continue
-            try:
-                session = object_session(value)
-                session.refresh(value)
-            except InvalidRequestError:
-                pass
             yield (value.__class__, [value.to_dict()])
 
     def _is_modified(self):

--- a/nefertari_sqla/tests/test_documents.py
+++ b/nefertari_sqla/tests/test_documents.py
@@ -567,8 +567,7 @@ class TestBaseMixin(object):
         myobj.update_iterables("", attr='settings', unique=False)
         assert myobj.settings == []
 
-    @patch.object(docs, 'object_session')
-    def test_get_reference_documents(self, mock_sess, memory_db):
+    def test_get_reference_documents(self, memory_db):
 
         class Child(docs.BaseDocument):
             __tablename__ = 'child'
@@ -591,9 +590,6 @@ class TestBaseMixin(object):
         assert len(result) == 1
         assert result[0][0] is Parent
         assert result[0][1] == [parent.to_dict()]
-
-        mock_sess.assert_called_with(parent)
-        mock_sess().refresh.assert_called_with(parent)
 
         # 'Many' side of relationship values are not returned
         assert child in parent.children


### PR DESCRIPTION
In signal handler `on_after_update` old value of one2one fields
is not updated explicitly. This is done because when changing
value of one2one field, `after_update` signal is not fired for
old value(document) of one2one field.