### PR TITLE
Rework DictField to use psql JSON type

### DIFF
--- a/nefertari_sqla/fields.py
+++ b/nefertari_sqla/fields.py
@@ -1,5 +1,7 @@
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.schema import Column, ForeignKey
+from sqlalchemy_utils.types.json import JSONType
+
 # Since SQLAlchemy 1.0.0
 # from sqlalchemy.types import MatchType
 from .types import (
@@ -20,7 +22,6 @@ from .types import (
     PickleType,
     Time,
     Choice,
-    Dict,
     ChoiceArray,
 )
 
@@ -276,7 +277,7 @@ class UnicodeTextField(StringField):
 
 
 class DictField(BaseField):
-    _sqla_type_cls = Dict
+    _sqla_type_cls = JSONType
     _type_unchanged_kwargs = ()
 
     def process_type_args(self, kwargs):

--- a/nefertari_sqla/tests/test_types.py
+++ b/nefertari_sqla/tests/test_types.py
@@ -168,50 +168,6 @@ class TestInterval(object):
         assert isinstance(value, datetime.timedelta)
 
 
-class TestDict(object):
-
-    def test_load_dialect_impl_postgresql(self):
-        field = types.Dict()
-        dialect = Mock()
-        dialect.name = 'postgresql'
-        field.load_dialect_impl(dialect=dialect)
-        assert field.is_postgresql
-        dialect.type_descriptor.assert_called_once_with(HSTORE)
-
-    def test_load_dialect_impl_not_postgresql(self):
-        from sqlalchemy.types import UnicodeText
-        field = types.Dict()
-        dialect = Mock()
-        dialect.name = 'some_other'
-        field.load_dialect_impl(dialect=dialect)
-        assert not field.is_postgresql
-        dialect.type_descriptor.assert_called_once_with(UnicodeText)
-
-    def test_process_bind_param_postgres(self):
-        field = types.Dict()
-        dialect = Mock()
-        dialect.name = 'postgresql'
-        assert {'q': 'f'} == field.process_bind_param({'q': 'f'}, dialect)
-
-    def test_process_bind_param_not_postgres(self):
-        field = types.Dict()
-        dialect = Mock()
-        dialect.name = 'some_other'
-        assert '{"q": "f"}' == field.process_bind_param({'q': 'f'}, dialect)
-
-    def test_process_result_value_postgres(self):
-        field = types.Dict()
-        dialect = Mock()
-        dialect.name = 'postgresql'
-        assert {'q': 'f'} == field.process_result_value({'q': 'f'}, dialect)
-
-    def test_process_result_value_not_postgres(self):
-        field = types.Dict()
-        dialect = Mock()
-        dialect.name = 'some_other'
-        assert {'q': 'f'} == field.process_result_value('{"q": "f"}', dialect)
-
-
 class TestChoiceArray(object):
 
     @patch.object(types, 'ARRAY')

--- a/nefertari_sqla/types.py
+++ b/nefertari_sqla/types.py
@@ -154,43 +154,6 @@ class Time(types.TypeDecorator):
     impl = types.Time
 
 
-class Dict(types.TypeDecorator):
-    """ Represents a dictionary of values.
-
-
-    If 'postgresql' is used, postgress.HSTORE type is used for db column
-    type. Otherwise `UnicodeText` is used.
-    """
-    impl = HSTORE
-
-    def load_dialect_impl(self, dialect):
-        """ Based on :dialect.name: determine type to be used.
-
-        `postgresql.HSTORE` is used in case `postgresql` database is used.
-        Otherwise `types.UnicodeText` is used.
-        """
-        if dialect.name == 'postgresql':
-            self.is_postgresql = True
-            return dialect.type_descriptor(HSTORE)
-        else:
-            self.is_postgresql = False
-            return dialect.type_descriptor(types.UnicodeText)
-
-    def process_bind_param(self, value, dialect):
-        if dialect.name == 'postgresql':
-            return value
-        if value is not None:
-            value = json.dumps(value)
-        return value
-
-    def process_result_value(self, value, dialect):
-        if dialect.name == 'postgresql':
-            return value
-        if value is not None:
-            value = json.loads(value)
-        return value
-
-
 class ChoiceArray(types.TypeDecorator):
     """ Represents a list of values.
 


### PR DESCRIPTION
* Implementation of custom Dict type is removed and JSONType
  from sqlalchemy_utils is used instead.
* Update ES map generation to check JSON type instead of Dict.
* Remove DictField querying support.