### PR TITLE
Disable DictField indexation

### DIFF
--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -73,7 +73,7 @@ TYPES_MAP = {
 
     types.Boolean: {'type': 'boolean'},
     types.LargeBinary: {'type': 'object'},
-    JSONType: {'type': 'object'},
+    JSONType: {'type': 'object', 'enabled': False},
 
     types.LimitedNumeric: {'type': 'double'},
     types.LimitedFloat: {'type': 'double'},

--- a/nefertari_sqla/tests/test_documents.py
+++ b/nefertari_sqla/tests/test_documents.py
@@ -98,7 +98,7 @@ class TestBaseMixin(object):
                 'properties': {
                     '_type': {'type': 'string'},
                     '_version': {'type': 'long'},
-                    'settings': {'type': 'object'},
+                    'settings': {'type': 'object', 'enabled': False},
                     'groups': {'type': 'string'},
                     'id': {'type': 'string'},
                     'my_id': {'type': 'long'},


### PR DESCRIPTION
Indexation of DictField is disabled to allow storing arbitrary JSON data in ES.
https://www.elastic.co/guide/en/elasticsearch/reference/1.4/mapping-object-type.html#_enabled_3