### PR TITLE
Fix _fields output from get_collection

### DIFF
--- a/nefertari_sqla/utils.py
+++ b/nefertari_sqla/utils.py
@@ -27,3 +27,7 @@ def get_relationship_cls(field, model_cls):
     relationships = {r.key: r for r in mapper.relationships}
     field_obj = relationships[field]
     return field_obj.mapper.class_
+
+
+class FieldsQuerySet(list):
+    pass


### PR DESCRIPTION
Field values are now returned as dict with proper field names
as keys. Explicitly requesting PK field from db and returning
it under _pk key.