### PR TITLE
 Rework data passed to processors

### DIFF
--- a/nefertari_sqla/__init__.py
+++ b/nefertari_sqla/__init__.py
@@ -9,7 +9,7 @@ from .serializers import JSONEncoder, ESJSONSerializer
 from .signals import ESMetaclass
 from .utils import (
     relationship_fields, is_relationship_field,
-    get_relationship_cls)
+    get_relationship_cls, FieldData)
 from .fields import (
     BigIntegerField,
     BooleanField,

--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -22,6 +22,7 @@ from .signals import ESMetaclass, on_bulk_delete
 from .fields import (
     ListField, DictField, IntegerField, apply_column_processors)
 from . import types
+from .utils import FieldData
 
 
 log = logging.getLogger(__name__)
@@ -806,10 +807,14 @@ class BaseDocument(BaseObject, BaseMixin):
             column = columns.get(name)
             if column is not None and hasattr(column, 'before_validation'):
                 new_value = getattr(self, name)
+                field = FieldData(
+                    name=name,
+                    params=getattr(column, '_init_kwargs', None),
+                )
                 proc_kwargs = {
                     'new_value': new_value,
                     'instance': self,
-                    'field': name,
+                    'field': field,
                     'request': getattr(self, '_request', None),
                 }
                 processed_value = apply_column_processors(

--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -807,14 +807,14 @@ class BaseDocument(BaseObject, BaseMixin):
             column = columns.get(name)
             if column is not None and hasattr(column, 'before_validation'):
                 new_value = getattr(self, name)
-                field = FieldData(
+                field_data = FieldData(
                     name=name,
                     params=getattr(column, '_init_kwargs', None),
                 )
                 proc_kwargs = {
                     'new_value': new_value,
                     'instance': self,
-                    'field': field,
+                    'field': field_data,
                     'request': getattr(self, '_request', None),
                 }
                 processed_value = apply_column_processors(

--- a/nefertari_sqla/fields.py
+++ b/nefertari_sqla/fields.py
@@ -541,6 +541,12 @@ class ProcessableRelationshipProperty(RelationshipProperty):
             return
         backref_field.before_validation = self.backref_before_validation
         backref_field.after_validation = self.backref_after_validation
+        backref_field._init_kwargs = {
+            'before_validation': backref_field.before_validation,
+            'after_validation': backref_field.after_validation,
+        }
+        if isinstance(self.backref, tuple):
+            backref_field._init_kwargs.update(self.backref[1])
 
     def _generate_backref(self, *args, **kwargs):
         """ Override to call `_set_backref_processors` after super. """

--- a/nefertari_sqla/utils.py
+++ b/nefertari_sqla/utils.py
@@ -36,3 +36,12 @@ def get_relationship_cls(field, model_cls):
 
 class FieldsQuerySet(list):
     pass
+
+
+class FieldData(object):
+    def __init__(self, name, params=None):
+        self.name = name
+        self.params = params
+
+    def __repr__(self):
+        return '<FieldData: {}>'.format(self.name)

--- a/nefertari_sqla/utils.py
+++ b/nefertari_sqla/utils.py
@@ -39,6 +39,10 @@ class FieldsQuerySet(list):
 
 
 class FieldData(object):
+    """ Keeps field data in a generic format.
+
+    Is passed to field processors.
+    """
     def __init__(self, name, params=None):
         self.name = name
         self.params = params


### PR DESCRIPTION
`field` kwarg passed to processors is now instance of `FieldData` which has 2 attributes:
`name` - name of field which is processed
`params` - params specified at field definition