### PR TITLE
Nesting and indexation improvements

### DIFF
--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -700,7 +700,6 @@ class BaseMixin(object):
             update_list(params)
 
     def get_reference_documents(self):
-        # TODO: Make lazy load of documents
         iter_props = class_mapper(self.__class__).iterate_properties
         backref_props = [p for p in iter_props
                          if isinstance(p, properties.RelationshipProperty)]

--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -699,7 +699,17 @@ class BaseMixin(object):
         elif is_list:
             update_list(params)
 
-    def get_related_documents(self):
+    def get_related_documents(self, nested_only=False):
+        """ Return pairs of (Model, istances) of relationship fields.
+
+        Pair contains of two elements:
+          :Model: Model class object(s) contained in field.
+          :instances: Model class instance(s) contained in field
+
+        :param nested_only: Boolean, defaults to False. When True, return
+            results only contain data for models on which current model
+            and field are nested.
+        """
         iter_props = class_mapper(self.__class__).iterate_properties
         backref_props = [p for p in iter_props
                          if isinstance(p, properties.RelationshipProperty)]
@@ -712,6 +722,12 @@ class BaseMixin(object):
             if not isinstance(value, list):
                 value = [value]
             model_cls = value[0].__class__
+
+            if nested_only:
+                backref = prop.back_populates
+                if backref and backref not in model_cls._nested_relationships:
+                    continue
+
             yield (model_cls, value)
 
     def _is_modified(self):

--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -604,11 +604,13 @@ class BaseMixin(object):
 
     def to_dict(self, **kwargs):
         native_fields = self.__class__.native_fields()
+        __depth = kwargs.get('__depth')
+        depth_reached = __depth is not None and __depth <= 0
         _data = {}
         for field in native_fields:
             value = getattr(self, field, None)
             include = field in self._nested_relationships
-            if not include:
+            if not include or depth_reached:
                 get_id = lambda v: getattr(v, v.pk_field(), None)
                 if isinstance(value, BaseMixin):
                     value = get_id(value)

--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -718,7 +718,7 @@ class BaseMixin(object):
             value = getattr(self, prop.key)
             # Do not index empty values
             if not value:
-                return
+                continue
             if not isinstance(value, list):
                 value = [value]
             model_cls = value[0].__class__

--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -699,18 +699,19 @@ class BaseMixin(object):
         elif is_list:
             update_list(params)
 
-    def get_reference_documents(self):
+    def get_related_documents(self):
         iter_props = class_mapper(self.__class__).iterate_properties
         backref_props = [p for p in iter_props
                          if isinstance(p, properties.RelationshipProperty)]
         for prop in backref_props:
             value = getattr(self, prop.key)
-            # Do not index empty values and 'Many' side in OneToMany,
-            # when 'One' side is indexed.
-            # If 'Many' side should be indexed, its value is already a list.
-            if value is None or isinstance(value, list):
-                continue
-            yield (value.__class__, [value.to_dict()])
+            # Do not index empty values
+            if value:
+                if not isinstance(value, list):
+                    value = [value]
+                value_type = value[0].__class__
+                documents = [val.to_dict() for val in value]
+                yield (value_type, documents)
 
     def _is_modified(self):
         """ Determine if instance is modified.

--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -703,15 +703,16 @@ class BaseMixin(object):
         iter_props = class_mapper(self.__class__).iterate_properties
         backref_props = [p for p in iter_props
                          if isinstance(p, properties.RelationshipProperty)]
+
         for prop in backref_props:
             value = getattr(self, prop.key)
             # Do not index empty values
-            if value:
-                if not isinstance(value, list):
-                    value = [value]
-                value_type = value[0].__class__
-                documents = [val.to_dict() for val in value]
-                yield (value_type, documents)
+            if not value:
+                return
+            if not isinstance(value, list):
+                value = [value]
+            model_cls = value[0].__class__
+            yield (model_cls, value)
 
     def _is_modified(self):
         """ Determine if instance is modified.

--- a/nefertari_sqla/signals.py
+++ b/nefertari_sqla/signals.py
@@ -15,7 +15,7 @@ def index_object(obj, with_refs=True, **kwargs):
     es = ES(obj.__class__.__name__)
     es.index(obj.to_dict(), **kwargs)
     if with_refs:
-        es.index_refs(obj, **kwargs)
+        es.index_relations(obj, **kwargs)
 
 
 def on_after_insert(mapper, connection, target):
@@ -56,7 +56,7 @@ def on_after_delete(mapper, connection, target):
     es = ES(model_cls.__name__)
     obj_id = getattr(target, model_cls.pk_field())
     es.delete(obj_id, request=request)
-    es.index_refs(target, request=request)
+    es.index_relations(target, request=request)
 
 
 def on_bulk_update(update_context):
@@ -77,7 +77,7 @@ def on_bulk_update(update_context):
 
     # Reindex relationships
     for obj in objects:
-        es.index_refs(obj, request=request)
+        es.index_relations(obj, request=request)
 
 
 def on_bulk_delete(model_cls, objects, request):
@@ -93,7 +93,7 @@ def on_bulk_delete(model_cls, objects, request):
 
     # Reindex relationships
     for obj in objects:
-        es.index_refs(obj, request=request)
+        es.index_relations(obj, request=request)
 
 
 def setup_es_signals_for(source_cls):

--- a/nefertari_sqla/signals.py
+++ b/nefertari_sqla/signals.py
@@ -46,7 +46,7 @@ def on_after_update(mapper, connection, target):
     # Reload `target` to get access to processed fields values
     columns = [c.name for c in class_mapper(target.__class__).columns]
     object_session(target).expire(target, attribute_names=columns)
-    index_object(target, request=request)
+    index_object(target, request=request, nested_only=True)
 
 
 def on_after_delete(mapper, connection, target):
@@ -77,7 +77,7 @@ def on_bulk_update(update_context):
 
     # Reindex relationships
     for obj in objects:
-        es.index_relations(obj, request=request)
+        es.index_relations(obj, request=request, nested_only=True)
 
 
 def on_bulk_delete(model_cls, objects, request):

--- a/nefertari_sqla/tests/test_documents.py
+++ b/nefertari_sqla/tests/test_documents.py
@@ -662,13 +662,13 @@ class TestBaseMixin(object):
         result = [v for v in child.get_related_documents()]
         assert len(result) == 1
         assert result[0][0] is Parent
-        assert result[0][1] == [parent.to_dict()]
+        assert result[0][1] == [parent]
 
         assert child in parent.children
         result = [v for v in parent.get_related_documents()]
         assert len(result) == 1
         assert result[0][0] is Child
-        assert result[0][1] == [child.to_dict()]
+        assert result[0][1] == [child]
 
     def test_is_modified_id_not_persistent(self, memory_db, simple_model):
         memory_db()

--- a/nefertari_sqla/tests/test_documents.py
+++ b/nefertari_sqla/tests/test_documents.py
@@ -555,6 +555,19 @@ class TestBaseMixin(object):
         assert result['other_obj3']['_type'] == 'MyModel'
         assert result['other_obj3']['id'] == 4
 
+    def test_to_dict_depth(self, memory_db):
+        class MyModel(docs.BaseDocument):
+            __tablename__ = 'mymodel'
+            _nested_relationships = ['other_obj']
+            id = fields.IdField(primary_key=True)
+            other_obj = fields.StringField()
+        memory_db()
+        myobj1 = MyModel(id=1)
+        myobj1.other_obj = MyModel(id=2)
+
+        result = myobj1.to_dict(__depth=0)
+        assert result['other_obj'] == 2
+
     @patch.object(docs, 'object_session')
     def test_update_iterables_dict(self, obj_session, memory_db):
         class MyModel(docs.BaseDocument):

--- a/nefertari_sqla/tests/test_documents.py
+++ b/nefertari_sqla/tests/test_documents.py
@@ -657,6 +657,7 @@ class TestBaseMixin(object):
 
         memory_db()
 
+        # Item
         parent = Parent(id=1)
         child = Child(id=1, parent=parent)
         result = [v for v in child.get_related_documents()]
@@ -664,11 +665,24 @@ class TestBaseMixin(object):
         assert result[0][0] is Parent
         assert result[0][1] == [parent]
 
+        # Collection
         assert child in parent.children
         result = [v for v in parent.get_related_documents()]
         assert len(result) == 1
         assert result[0][0] is Child
         assert result[0][1] == [child]
+
+        # nested_only=True for nested object
+        Child._nested_relationships = ('parent',)
+        result = [v for v in parent.get_related_documents(nested_only=True)]
+        assert len(result) == 1
+        assert result[0][0] is Child
+        assert result[0][1] == [child]
+
+        # nested_only=True for NOT nested object
+        Parent._nested_relationships = ()
+        result = [v for v in child.get_related_documents(nested_only=True)]
+        assert len(result) == 0
 
     def test_is_modified_id_not_persistent(self, memory_db, simple_model):
         memory_db()

--- a/nefertari_sqla/tests/test_documents.py
+++ b/nefertari_sqla/tests/test_documents.py
@@ -640,7 +640,7 @@ class TestBaseMixin(object):
         myobj.update_iterables("", attr='settings', unique=False)
         assert myobj.settings == []
 
-    def test_get_reference_documents(self, memory_db):
+    def test_get_related_documents(self, memory_db):
 
         class Child(docs.BaseDocument):
             __tablename__ = 'child'
@@ -659,15 +659,16 @@ class TestBaseMixin(object):
 
         parent = Parent(id=1)
         child = Child(id=1, parent=parent)
-        result = [v for v in child.get_reference_documents()]
+        result = [v for v in child.get_related_documents()]
         assert len(result) == 1
         assert result[0][0] is Parent
         assert result[0][1] == [parent.to_dict()]
 
-        # 'Many' side of relationship values are not returned
         assert child in parent.children
-        result = [v for v in parent.get_reference_documents()]
-        assert len(result) == 0
+        result = [v for v in parent.get_related_documents()]
+        assert len(result) == 1
+        assert result[0][0] is Child
+        assert result[0][1] == [child.to_dict()]
 
     def test_is_modified_id_not_persistent(self, memory_db, simple_model):
         memory_db()


### PR DESCRIPTION
* BaseMixin.to_dict now supports __depth param which is used to specify nesting depth.
* BaseMixin.get_related_documents also processes fields which hold collections of objects.
* BaseMixin.get_related_documents has new param nested_only. When True, return results only contain data for models on which current model and field are nested.
* BaseMixin.get_related_documents second item in yielded results must be list of DB objects and not dicts.