### PR TITLE
Fix query with dot notation on nested objects

### DIFF
--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -633,13 +633,14 @@ class BaseMixin(object):
         if isinstance(items, Query):
             upd_queryset = cls._clean_queryset(items)
             upd_queryset._request = request
+            updated_item = upd_queryset.all()
             upd_count = upd_queryset.update(
                 params, synchronize_session=synchronize_session)
-            return upd_count
+            return {"count": upd_count, "items": updated_item}
         items_count = len(items)
         for item in items:
             item.update(params, request)
-        return items_count
+        return {"count": items_count, "items": items}
 
     @classmethod
     def _clean_queryset(cls, queryset):

--- a/nefertari_sqla/tests/test_documents.py
+++ b/nefertari_sqla/tests/test_documents.py
@@ -462,7 +462,7 @@ class TestBaseMixin(object):
 
     def test_underscore_update_many(self):
         item = Mock()
-        assert docs.BaseMixin._update_many([item], {'foo': 'bar'}) == 1
+        assert docs.BaseMixin._update_many([item], {'foo': 'bar'}) == {'count': 1, 'items': [item]}
         item.update.assert_called_once_with({'foo': 'bar'}, None)
 
     @patch.object(docs.BaseMixin, '_clean_queryset')
@@ -473,11 +473,11 @@ class TestBaseMixin(object):
         clean_items.all = Mock(return_value=[1, 2, 3])
         clean_items.update = Mock()
         mock_clean.return_value = clean_items
-        count = docs.BaseMixin._update_many(items, {'foo': 'bar'})
+        result = docs.BaseMixin._update_many(items, {'foo': 'bar'})
         mock_clean.assert_called_once_with(items)
         clean_items.update.assert_called_once_with(
             {'foo': 'bar'}, synchronize_session='fetch')
-        assert count == clean_items.update()
+        assert result['count'] == clean_items.update()
 
     def test_repr(self, simple_model, memory_db):
         obj = simple_model()


### PR DESCRIPTION
To be able to query using the dot notation, we need to copy the object to the parent. This is done using the include_in_parent on the field mapping.